### PR TITLE
Fix ipInrange method with $cidr without range

### DIFF
--- a/Plugin/Magento/Framework/Session/SessionManagerPlugin.php
+++ b/Plugin/Magento/Framework/Session/SessionManagerPlugin.php
@@ -187,6 +187,11 @@ class SessionManagerPlugin
      */
     private function ipInRange($ip, $cidr)
     {
+        // Keep working with single ip without range
+        if (strpos($cidr, '/') === false) {
+            $cidr .= '/32';
+        }
+
         list($subnet, $mask) = explode('/', $cidr);
         return (ip2long($ip) & ~((1 << (32 - $mask)) - 1)) == ip2long($subnet);
     }


### PR DESCRIPTION
This prevent to fail when the $cidr has no range. The fix will add a range of "/32" to indicate is a single ip